### PR TITLE
Added `PART HARM` track names

### DIFF
--- a/doc/FileFormats/.mid/Standard/Vocals.md
+++ b/doc/FileFormats/.mid/Standard/Vocals.md
@@ -14,9 +14,8 @@
 ## Track Names
 
 - `PART VOCALS` - Standard vocals track
-- `HARM1` - Harmonies track 1
-- `HARM2` - Harmonies track 2
-- `HARM3` - Harmonies track 3
+- `HARM1`, `HARM2`, `HARM3` - Harmonies track 1, 2, and 3 respectively
+- `PART HARM1`, `PART HARM2`, `PART HARM3` - Alternative harmony track names
 
 ## Track Notes
 


### PR DESCRIPTION
I noticed that The Beatles Rock Band games use `PART HARM1`, `PART HARM2`, and `PART HARM3`, instead of `HARM1`, `HARM2`, `HARM3`. I added this to the documentation.