### PR TITLE
Updated documentation for GHL keys tracks.

### DIFF
--- a/docs/Chart-File-Formats/chart-format/Tracks/6-Fret-Guitar.md
+++ b/docs/Chart-File-Formats/chart-format/Tracks/6-Fret-Guitar.md
@@ -21,6 +21,7 @@ Instrument names:
 - `GHLBass` – Guitar Hero Live Bass
 - `GHLRhythm` - Guitar Hero Live Rhythm
 - `GHLCoop` - Guitar Hero Live Co-op
+- `GHLKeys` - Guitar Hero Live Keys
 
 Difficulties:
 

--- a/docs/Chart-File-Formats/mid-format/Tracks/6-Fret-Guitar.md
+++ b/docs/Chart-File-Formats/mid-format/Tracks/6-Fret-Guitar.md
@@ -6,6 +6,7 @@
 - `PART BASS GHL` - 6-Fret Bass Guitar
 - `PART RHYTHM GHL` - 6-Fret Rhythm Guitar
 - `PART GUITAR COOP GHL` - 6-Fret Co-op Guitar
+- `PART KEYS GHL` - 6-Fret Co-op Guitar
 
 ## Track Notes
 

--- a/docs/Chart-File-Formats/mid-format/Tracks/6-Fret-Guitar.md
+++ b/docs/Chart-File-Formats/mid-format/Tracks/6-Fret-Guitar.md
@@ -6,7 +6,7 @@
 - `PART BASS GHL` - 6-Fret Bass Guitar
 - `PART RHYTHM GHL` - 6-Fret Rhythm Guitar
 - `PART GUITAR COOP GHL` - 6-Fret Co-op Guitar
-- `PART KEYS GHL` - 6-Fret Co-op Guitar
+- `PART KEYS GHL` - 6-Fret Keys
 
 ## Track Notes
 


### PR DESCRIPTION
Moonscraper has been updated to allow a GHL version of the Keys track. Clone Hero should be getting this update at some point soon. 