### PR TITLE
Document extended lane functionality

### DIFF
--- a/docs/Chart-File-Formats/chart-format/Tracks/Drums.md
+++ b/docs/Chart-File-Formats/chart-format/Tracks/Drums.md
@@ -147,6 +147,7 @@ Accent and ghost notes are notes that notate relatively louder or quieter notes 
 | Roll lanes   |                                    |
 | 65           | 1-lane roll marker                 |
 | 66           | 2-lane roll marker                 |
+| 67           | Kick roll marker                   |
 
 #### Special Phrase Mechanics
 

--- a/docs/Chart-File-Formats/mid-format/Tracks/Drums.md
+++ b/docs/Chart-File-Formats/mid-format/Tracks/Drums.md
@@ -75,6 +75,7 @@ Here are some suggested conversions between different drum types:
 | Markers   |                                              |
 | 127       | 2-lane roll marker                           |
 | 126       | 1-lane roll marker                           |
+| 125       | Kick roll marker                             |
 | 124       | Fill/Big Rock Ending marker 1                |
 | 123       | Fill/Big Rock Ending marker 2                |
 | 122       | Fill/Big Rock Ending marker 3                |
@@ -141,7 +142,10 @@ Roll lanes are used to make imprecise/indiscernible rhythms such as drum rolls o
   - Single-lane rolls are used for drum or cymbal rolls that only apply to a single lane at a time.
   - Double-lane rolls are used when alternating between two different lanes.
 - If a single-lane roll starts on a chord (excluding kicks), the next non-chord note determines which lane the roll goes on.
-- Roll lanes only apply to Expert unless they are marked at a velocity between 50-41, in which case they apply to Hard as well.
+- Roll lanes only apply to Expert by default. By setting a roll lane's marker note within one of the following velocity ranges, the roll lane can carry down to LDs:
+  - `[41,50]` applies the roll lane to Expert and Hard
+  - `[31,40]` applies the roll lane to Expert, Hard, and Medium. This range is not supported by RB3
+  - `[21,30]` applies the roll lane to all difficulties. This range is not supported by RB3
 
 Fill markers are used to mark phrases in which a player can activate Star Power. These phrases can either replace the notes within the phrase with a freestyle phrase, or they can keep the existing notes and just mark the end of the phrase as an activation point (referred to as "static" fills).
 


### PR DESCRIPTION
Adds documentation for two pieces of lane functionality that go beyond what RB3 supports.

1) Documents using the `[31,40]` and `[21,30]` velocity ranges for `.mid`-based lane marker notes to carry lanes down to XHM and XHME(B), respectively. Both CH and YARG support this without any need for a text event flag; I call out in the new documentation that RB3 does not recognize these.

2) Documents YARG's [support for kick lanes](https://github.com/YARC-Official/YARG/pull/1581), notated via note 125 in `.mid` and phrase 67 in `.chart`.

While I called out RB3's specific nonsupport of the velocity ranges, I wasn't sure how (if) we'd want to mark kick lanes since it's (thus far) a YARG-only feature. Saying "YARG only" becomes inaccurate as soon as literally any other game (however notable) follows suit, but listing games that do _not_ support it quickly becomes verbose. Left it unclarified for now.